### PR TITLE
Add a CLI skeleton based on Hanami::CLI

### DIFF
--- a/bump-cli.gemspec
+++ b/bump-cli.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "hanami-cli"
+
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/bump-cli.gemspec
+++ b/bump-cli.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "minitest-hooks"
+  spec.add_development_dependency "climate_control"
 end

--- a/exe/bump
+++ b/exe/bump
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "bump/cli"
+
+Bump::CLI.new.call

--- a/lib/bump/cli.rb
+++ b/lib/bump/cli.rb
@@ -1,7 +1,33 @@
 require "bump/cli/version"
+require "hanami/cli"
 
 module Bump
-  module CLI
-    # Your code goes here...
+  class CLI
+    def call(*args)
+      Hanami::CLI.new(Commands).call(*args)
+    end
+
+    module Commands
+      extend Hanami::CLI::Registry
+
+      class Validate < Hanami::CLI::Command
+        desc "Validate API documentation file"
+
+        def call(*)
+          puts "Validating..."
+        end
+      end
+
+      class Deploy < Hanami::CLI::Command
+        desc "Deploy the latest API version docs"
+
+        def call(*)
+          puts "Deploying..."
+        end
+      end
+    end
   end
 end
+
+Bump::CLI::Commands.register "validate", Bump::CLI::Commands::Validate
+Bump::CLI::Commands.register "deploy",   Bump::CLI::Commands::Deploy

--- a/lib/bump/cli/version.rb
+++ b/lib/bump/cli/version.rb
@@ -1,5 +1,5 @@
 module Bump
-  module CLI
+  class CLI
     VERSION = "0.1.0"
   end
 end

--- a/test/bump/cli_test.rb
+++ b/test/bump/cli_test.rb
@@ -1,17 +1,11 @@
 require "test_helper"
 
 describe Bump::CLI do
-  before do
-    @original_path = ENV['PATH']
-    ENV['PATH'] = File.expand_path("../../..", __FILE__) + '/exe:' + ENV['PATH']
-  end
-
-  after do
-    ENV['PATH'] = @original_path
-  end
-
-  it "has a version number" do
-    refute_nil ::Bump::CLI::VERSION
+  around do |&block|
+    modified_path = File.expand_path("../../..", __FILE__) + '/exe:' + ENV['PATH']
+    ClimateControl.modify PATH: modified_path do
+      super(&block)
+    end
   end
 
   describe "validate command" do

--- a/test/bump/cli_test.rb
+++ b/test/bump/cli_test.rb
@@ -1,7 +1,32 @@
 require "test_helper"
 
-class Bump::CLITest < Minitest::Test
-  def test_that_it_has_a_version_number
+describe Bump::CLI do
+  before do
+    @original_path = ENV['PATH']
+    ENV['PATH'] = File.expand_path("../../..", __FILE__) + '/exe:' + ENV['PATH']
+  end
+
+  after do
+    ENV['PATH'] = @original_path
+  end
+
+  it "has a version number" do
     refute_nil ::Bump::CLI::VERSION
+  end
+
+  describe "validate command" do
+    it "outputs the right thing" do
+      output = `bump validate`
+
+      assert_equal output.chomp, "Validating..."
+    end
+  end
+
+  describe "deploy command" do
+    it "outputs the right thing" do
+      output = `bump deploy`
+
+      assert_equal output.chomp, "Deploying..."
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,6 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "bump/cli"
 
+require "climate_control"
+require "minitest/hooks/default"
 require "minitest/autorun"


### PR DESCRIPTION
Planned commands are:

- `bump validate`
- `bump deploy`

Those will probably take some options or have subcommands. 
Currently doing only a `puts`.

I wanted to give Hanami::CLI a try instead of going with other tools like Thor or fancier like mruby-cli.
Also, what about writing it as a go binary? I think it much better, for users without a Ruby env