### PR TITLE
Simplify authentication

### DIFF
--- a/lib/bump/cli/commands/base.rb
+++ b/lib/bump/cli/commands/base.rb
@@ -6,14 +6,17 @@ module Bump
       class Base < Hanami::CLI::Command
         private
 
-        def headers(options)
-          default_headers
-        end
-
-        def default_headers
-          {
-            "Content-Type" => "application/json"
-          }
+        def headers(token: '')
+          if token
+            {
+              "Content-Type" => "application/json",
+              "Authorization" => "Basic #{Base64.strict_encode64(token + ':')}"
+            }
+          else
+            {
+              "Content-Type" => "application/json"
+            }
+          end
         end
 
         def display_error(response)
@@ -21,7 +24,7 @@ module Bump
             body = JSON.parse(response.body)
             display_invalid_definition(body)
           elsif response.code == 401
-            abort "Invalid authentication string (status: 401)"
+            abort "Invalid credentials (status: 401)"
           else
             body = JSON.parse(response.body)
             abort "Error : #{body["message"]} (status: #{response.code})"

--- a/lib/bump/cli/commands/deploy.rb
+++ b/lib/bump/cli/commands/deploy.rb
@@ -6,11 +6,11 @@ module Bump
       class Deploy < Base
         desc "Creates a new version"
         argument :file, required: true, desc: "Path or URL to your API documentation file. Only OpenApi 2.0 (Swagger) specification is currently supported."
-        option :id, desc: "Documentation public id"
-        option :token, desc: "Documentation private token"
+        option :id, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation public id"
+        option :token, default: ENV.fetch("BUMP_TOKEN", ""), desc: "Documentation private token"
         option :format, default: "yaml", values: %w[yaml json], desc: "Format of the definition"
 
-        def call(file:, format:, id: "", token: "")
+        def call(file:, format:, id:, token:)
           response = HTTP
             .headers(headers(token: token))
             .post(API_URL + "/docs/#{id}/versions", body: body(file, format).to_json)

--- a/lib/bump/cli/commands/deploy.rb
+++ b/lib/bump/cli/commands/deploy.rb
@@ -4,7 +4,7 @@ module Bump
   class CLI
     module Commands
       class Deploy < Base
-        desc "Creates a new version"
+        desc "Create a new version"
         argument :file, required: true, desc: "Path or URL to your API documentation file. Only OpenApi 2.0 (Swagger) specification is currently supported."
         option :id, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation public id"
         option :token, default: ENV.fetch("BUMP_TOKEN", ""), desc: "Documentation private token"

--- a/lib/bump/cli/commands/deploy.rb
+++ b/lib/bump/cli/commands/deploy.rb
@@ -5,13 +5,15 @@ module Bump
     module Commands
       class Deploy < Base
         desc "Creates a new version"
-        argument :authentication, required: true, desc: "Authentication string, following this format: DOC_ID:DOC_TOKEN."
         argument :file, required: true, desc: "Path or URL to your API documentation file. Only OpenApi 2.0 (Swagger) specification is currently supported."
+        option :id, desc: "Documentation public id"
+        option :token, desc: "Documentation private token"
         option :format, default: "yaml", values: %w[yaml json], desc: "Format of the definition"
 
-        def call(**options)
-          id, token = options.fetch(:authentication).split(':')
-          response = HTTP.headers(headers(token)).post(API_URL + "/docs/#{id}/versions", body: body(options).to_json)
+        def call(file:, format:, id: "", token: "")
+          response = HTTP
+            .headers(headers(token: token))
+            .post(API_URL + "/docs/#{id}/versions", body: body(file, format).to_json)
 
           if response.code == 201
             puts "New version has been successfuly deployed."
@@ -26,14 +28,10 @@ module Bump
 
         private
 
-        def headers(token)
-          default_headers.merge("Authorization" => "Basic #{Base64.strict_encode64(token + ':')}")
-        end
-
-        def body(options)
+        def body(file, format)
           {
-            definition: open(options.fetch(:file)).read,
-            format: options.fetch(:format)
+            definition: open(file).read,
+            format: format
           }
         end
       end

--- a/lib/bump/cli/commands/preview.rb
+++ b/lib/bump/cli/commands/preview.rb
@@ -7,7 +7,9 @@ module Bump
         option :format, default: "yaml", values: %w[yaml json], desc: "Format of the definition"
 
         def call(**options)
-          response = HTTP.headers(headers(options)).post(API_URL + "/previews", body: body(options).to_json)
+          response = HTTP
+            .headers(headers)
+            .post(API_URL + "/previews", body: body(options).to_json)
 
           if response.code == 201
             body = JSON.parse(response.body)

--- a/lib/bump/cli/commands/validate.rb
+++ b/lib/bump/cli/commands/validate.rb
@@ -4,7 +4,7 @@ module Bump
   class CLI
     module Commands
       class Validate < Base
-        desc "Validates a given file against its schema definition"
+        desc "Validate a given file against its schema definition"
         argument :file, required: true, desc: "Path or URL to your API documentation file. Only OpenApi 2.0 (Swagger) specification is currently supported."
         option :id, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation public id"
         option :token, default: ENV.fetch("BUMP_TOKEN", ""), desc: "Documentation private token"

--- a/lib/bump/cli/commands/validate.rb
+++ b/lib/bump/cli/commands/validate.rb
@@ -6,11 +6,11 @@ module Bump
       class Validate < Base
         desc "Validates a given file against its schema definition"
         argument :file, required: true, desc: "Path or URL to your API documentation file. Only OpenApi 2.0 (Swagger) specification is currently supported."
-        option :id, desc: "Documentation public id"
-        option :token, desc: "Documentation private token"
+        option :id, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation public id"
+        option :token, default: ENV.fetch("BUMP_TOKEN", ""), desc: "Documentation private token"
         option :format, default: "yaml", values: %w[yaml json], desc: "Format of the definition"
 
-        def call(file:, format:, id: "", token: "")
+        def call(file:, format:, id:, token:)
           response = HTTP
             .headers(headers(token: token))
             .post(API_URL + "/docs/#{id}/validations", body: body(file, format).to_json)

--- a/spec/bump/commands/deploy_spec.rb
+++ b/spec/bump/commands/deploy_spec.rb
@@ -5,7 +5,7 @@ describe Bump::CLI::Commands::Deploy do
     stub_bump_api_validate('versions/post_success.http')
 
     expect do
-      new_command.call(authentication: '1:token', file: 'path/to/file', format: 'yaml')
+      new_command.call(id: '1', token:'token', file: 'path/to/file', format: 'yaml')
     end.to output(/New version has been successfuly deployed/).to_stdout
 
     expect(WebMock).to have_requested(:post,'https://bump.sh/api/v1/docs/1/versions').with(
@@ -21,7 +21,7 @@ describe Bump::CLI::Commands::Deploy do
 
     expect do
       begin
-        new_command.call(authentication: 'YO:LO', file: 'path/to/file', format: 'yaml')
+        new_command.call(id: '1', token: 'token', file: 'path/to/file', format: 'yaml')
       rescue SystemExit; end
     end.to output(/Definition is not valid/).to_stdout
   end
@@ -31,7 +31,7 @@ describe Bump::CLI::Commands::Deploy do
 
     expect do
       begin
-        new_command.call(authentication: 'YO:LO', file: 'path/to/file', format: 'yaml')
+        new_command.call(id: '1', token: 'token', file: 'path/to/file', format: 'yaml')
       rescue SystemExit; end
     end.to output(/Unknown error/).to_stderr
   end

--- a/spec/bump/commands/validate_spec.rb
+++ b/spec/bump/commands/validate_spec.rb
@@ -5,7 +5,7 @@ describe Bump::CLI::Commands::Validate do
     stub_bump_api_validate('validations/post_success.http')
 
     expect do
-      new_command.call(authentication: '1:token', file: 'path/to/file', format: 'yaml')
+      new_command.call(id: '1', token:'token', file: 'path/to/file', format: 'yaml')
     end.to output(/Definition is valid/).to_stdout
 
     expect(WebMock).to have_requested(:post,'https://bump.sh/api/v1/docs/1/validations').with(
@@ -21,7 +21,7 @@ describe Bump::CLI::Commands::Validate do
 
     expect do
       begin
-        new_command.call(authentication: 'YO:LO', file: 'path/to/file', format: 'yaml')
+        new_command.call(id: '1', token:'token', file: 'path/to/file', format: 'yaml')
       rescue SystemExit; end
     end.to output(/Definition is not valid/).to_stdout
   end
@@ -31,7 +31,7 @@ describe Bump::CLI::Commands::Validate do
 
     expect do
       begin
-        new_command.call(authentication: 'YO:LO', file: 'path/to/file', format: 'yaml')
+        new_command.call(id: '1', token:'token', file: 'path/to/file', format: 'yaml')
       rescue SystemExit; end
     end.to output(/Unknown error/).to_stderr
   end


### PR DESCRIPTION
Here, we remove the old code for authentication which was too much complex, to replace it by simple options which default to environment variables. This will let us use the gem hiding the private token (use an environment variable instead).