### PR TITLE
Replace the format parameter by the specification one

### DIFF
--- a/lib/bump/cli/commands/base.rb
+++ b/lib/bump/cli/commands/base.rb
@@ -6,6 +6,13 @@ module Bump
       class Base < Hanami::CLI::Command
         private
 
+        def body(file, specification)
+          {
+            definition: open(file).read,
+            specification: specification
+          }
+        end
+
         def with_errors_rescued
           yield
         rescue HTTP::Error, Errno::ENOENT, SocketError => error

--- a/lib/bump/cli/commands/deploy.rb
+++ b/lib/bump/cli/commands/deploy.rb
@@ -8,13 +8,13 @@ module Bump
         argument :file, required: true, desc: "Path or URL to your API documentation file. Only OpenApi 2.0 (Swagger) specification is currently supported."
         option :id, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation public id"
         option :token, default: ENV.fetch("BUMP_TOKEN", ""), desc: "Documentation private token"
-        option :format, default: "yaml", values: %w[yaml json], desc: "Format of the definition"
+        option :specification, default: 'openapi/v2/yaml', values: %w[openapi/v2/json openapi/v2/yaml], desc: "Specification of the definition"
 
-        def call(file:, format:, id:, token:)
+        def call(file:, specification:, id:, token:)
           with_errors_rescued do
             response = HTTP
               .headers(headers(token: token))
-              .post(API_URL + "/docs/#{id}/versions", body: body(file, format).to_json)
+              .post(API_URL + "/docs/#{id}/versions", body: body(file, specification).to_json)
 
             if response.code == 201
               puts "New version has been successfully deployed."
@@ -24,15 +24,6 @@ module Bump
               display_error(response)
             end
           end
-        end
-
-        private
-
-        def body(file, format)
-          {
-            definition: open(file).read,
-            format: format
-          }
         end
       end
     end

--- a/lib/bump/cli/commands/preview.rb
+++ b/lib/bump/cli/commands/preview.rb
@@ -4,13 +4,13 @@ module Bump
       class Preview < Base
         desc "Create a documentation preview for the given file"
         argument :file, required: true, desc: "Path or URL to your API documentation file. Only OpenApi 2.0 (Swagger) specification is currently supported."
-        option :format, default: "yaml", values: %w[yaml json], desc: "Format of the definition"
+        option :specification, default: 'openapi/v2/yaml', values: %w[openapi/v2/json openapi/v2/yaml], desc: "Specification of the definition"
 
-        def call(**options)
+        def call(file:, specification:)
           with_errors_rescued do
             response = HTTP
               .headers(headers)
-              .post(API_URL + "/previews", body: body(options).to_json)
+              .post(API_URL + "/previews", body: body(file, specification).to_json)
 
             if response.code == 201
               body = JSON.parse(response.body)
@@ -19,15 +19,6 @@ module Bump
               display_error(response)
             end
           end
-        end
-
-        private
-
-        def body(options)
-          {
-            definition: open(options.fetch(:file)).read,
-            format: options.fetch(:format)
-          }
         end
       end
     end

--- a/lib/bump/cli/commands/validate.rb
+++ b/lib/bump/cli/commands/validate.rb
@@ -8,13 +8,13 @@ module Bump
         argument :file, required: true, desc: "Path or URL to your API documentation file. Only OpenApi 2.0 (Swagger) specification is currently supported."
         option :id, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation public id"
         option :token, default: ENV.fetch("BUMP_TOKEN", ""), desc: "Documentation private token"
-        option :format, default: "yaml", values: %w[yaml json], desc: "Format of the definition"
+        option :specification, default: 'openapi/v2/yaml', values: %w[openapi/v2/json openapi/v2/yaml], desc: "Specification of the definition"
 
-        def call(file:, format:, id:, token:)
+        def call(file:, specification:, id:, token:)
           with_errors_rescued do
             response = HTTP
               .headers(headers(token: token))
-              .post(API_URL + "/docs/#{id}/validations", body: body(file, format).to_json)
+              .post(API_URL + "/docs/#{id}/validations", body: body(file, specification).to_json)
 
             if response.code == 200
               puts "Definition is valid."
@@ -22,15 +22,6 @@ module Bump
               display_error(response)
             end
           end
-        end
-
-        private
-
-        def body(file, format)
-          {
-            definition: open(file).read,
-            format: format
-          }
         end
       end
     end

--- a/spec/bump/commands/deploy_spec.rb
+++ b/spec/bump/commands/deploy_spec.rb
@@ -5,13 +5,13 @@ describe Bump::CLI::Commands::Deploy do
     stub_bump_api_validate('versions/post_success.http')
 
     expect do
-      new_command.call(id: '1', token:'token', file: 'path/to/file', format: 'yaml')
+      new_command.call(id: '1', token:'token', file: 'path/to/file', specification: 'openapi/v2/json')
     end.to output(/New version has been successfully deployed/).to_stdout
 
     expect(WebMock).to have_requested(:post,'https://bump.sh/api/v1/docs/1/versions').with(
       body: {
         definition: 'body',
-        format: 'yaml'
+        specification: 'openapi/v2/json'
       }
     )
   end
@@ -21,7 +21,7 @@ describe Bump::CLI::Commands::Deploy do
 
     expect do
       begin
-        new_command.call(id: '1', token: 'token', file: 'path/to/file', format: 'yaml')
+        new_command.call(id: '1', token: 'token', file: 'path/to/file', specification: 'openapi/v2/yaml')
       rescue SystemExit; end
     end.to output(/Definition is not valid/).to_stdout
   end
@@ -31,7 +31,7 @@ describe Bump::CLI::Commands::Deploy do
 
     expect do
       begin
-        new_command.call(id: '1', token: 'token', file: 'path/to/file', format: 'yaml')
+        new_command.call(id: '1', token: 'token', file: 'path/to/file', specification: 'openapi/v2/yaml')
       rescue SystemExit; end
     end.to output(/Unknown error/).to_stderr
   end

--- a/spec/bump/commands/preview_spec.rb
+++ b/spec/bump/commands/preview_spec.rb
@@ -5,7 +5,7 @@ describe Bump::CLI::Commands::Preview do
     stub_bump_api_create_preview('previews/post_success.http')
 
     expect do
-      new_command.call(file: 'path/to/file', format: 'yaml')
+      new_command.call(file: 'path/to/file', specification: 'openapi/v3/yaml')
     end.to output(/Preview created/).to_stdout
 
     expect(WebMock).to have_requested(:post,'https://bump.sh/api/v1/previews').with(
@@ -14,7 +14,7 @@ describe Bump::CLI::Commands::Preview do
       },
       body: {
         definition: 'body',
-        format: 'yaml'
+        specification: 'openapi/v3/yaml'
       }
     )
   end
@@ -24,7 +24,7 @@ describe Bump::CLI::Commands::Preview do
 
     expect do
       begin
-        new_command.call(file: 'path/to/file', format: 'yaml')
+        new_command.call(file: 'path/to/file', specification: 'openapi/v2/yaml')
       rescue SystemExit; end
     end.to output(/Definition is not valid/).to_stdout
 
@@ -36,7 +36,7 @@ describe Bump::CLI::Commands::Preview do
 
     expect do
       begin
-        new_command.call(file: 'path/to/file', format: 'yaml')
+        new_command.call(file: 'path/to/file', specification: 'openapi/v2/yaml')
       rescue SystemExit; end
     end.to output(/Oops. Something bad happened./).to_stderr
 

--- a/spec/bump/commands/validate_spec.rb
+++ b/spec/bump/commands/validate_spec.rb
@@ -5,13 +5,13 @@ describe Bump::CLI::Commands::Validate do
     stub_bump_api_validate('validations/post_success.http')
 
     expect do
-      new_command.call(id: '1', token:'token', file: 'path/to/file', format: 'yaml')
+      new_command.call(id: '1', token:'token', file: 'path/to/file', specification: 'api-blueprint/v1a9')
     end.to output(/Definition is valid/).to_stdout
 
     expect(WebMock).to have_requested(:post,'https://bump.sh/api/v1/docs/1/validations').with(
       body: {
         definition: 'body',
-        format: 'yaml'
+        specification: 'api-blueprint/v1a9'
       }
     )
   end
@@ -21,7 +21,7 @@ describe Bump::CLI::Commands::Validate do
 
     expect do
       begin
-        new_command.call(id: '1', token:'token', file: 'path/to/file', format: 'yaml')
+        new_command.call(id: '1', token:'token', file: 'path/to/file', specification: 'openapi/v2/yaml')
       rescue SystemExit; end
     end.to output(/Definition is not valid/).to_stdout
   end
@@ -31,7 +31,7 @@ describe Bump::CLI::Commands::Validate do
 
     expect do
       begin
-        new_command.call(id: '1', token:'token', file: 'path/to/file', format: 'yaml')
+        new_command.call(id: '1', token:'token', file: 'path/to/file', specification: 'openapi/v2/yaml')
       rescue SystemExit; end
     end.to output(/Unknown error/).to_stderr
   end


### PR DESCRIPTION
As the API has changed we need to update the CLI. This can be done because we don't have any real active user at the moment, but it's probably the only time we'll do that.