### PR TITLE
Mention OpenAPI 3.0 in commands help

### DIFF
--- a/lib/bump/cli/commands/deploy.rb
+++ b/lib/bump/cli/commands/deploy.rb
@@ -5,7 +5,7 @@ module Bump
     module Commands
       class Deploy < Base
         desc "Create a new version"
-        argument :file, required: true, desc: "Path or URL to your API documentation file. Only OpenApi 2.0 (Swagger) specification is currently supported."
+        argument :file, required: true, desc: "Path or URL to your API documentation file. OpenApi 2.0 and 3.0 specifications are currently supported."
         option :id, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation public id"
         option :token, default: ENV.fetch("BUMP_TOKEN", ""), desc: "Documentation private token"
         option :specification, desc: "Specification of the definition"

--- a/lib/bump/cli/commands/preview.rb
+++ b/lib/bump/cli/commands/preview.rb
@@ -3,7 +3,7 @@ module Bump
     module Commands
       class Preview < Base
         desc "Create a documentation preview for the given file"
-        argument :file, required: true, desc: "Path or URL to your API documentation file. Only OpenApi 2.0 (Swagger) specification is currently supported."
+        argument :file, required: true, desc: "Path or URL to your API documentation file. OpenApi 2.0 and 3.0 specifications are currently supported."
         option :specification, desc: "Specification of the definition"
 
         def call(file:, specification: nil)

--- a/lib/bump/cli/commands/validate.rb
+++ b/lib/bump/cli/commands/validate.rb
@@ -5,7 +5,7 @@ module Bump
     module Commands
       class Validate < Base
         desc "Validate a given file against its schema definition"
-        argument :file, required: true, desc: "Path or URL to your API documentation file. Only OpenApi 2.0 (Swagger) specification is currently supported."
+        argument :file, required: true, desc: "Path or URL to your API documentation file. OpenApi 2.0 and 3.0 specifications are currently supported."
         option :id, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation public id"
         option :token, default: ENV.fetch("BUMP_TOKEN", ""), desc: "Documentation private token"
         option :specification, desc: "Specification of the definition"


### PR DESCRIPTION
Commands help was only mentioning OpenAPI 2.0, but 3.0 is supported too.