### PR TITLE
Support the validation parameter

### DIFF
--- a/lib/bump/cli/commands/base.rb
+++ b/lib/bump/cli/commands/base.rb
@@ -14,10 +14,11 @@ module Bump
             .post(url, body: body)
         end
 
-        def body(file, specification)
+        def body(file, specification, validation)
           {
             definition: open(file).read,
-            specification: specification
+            specification: specification,
+            validation: validation
           }
         end
 

--- a/lib/bump/cli/commands/deploy.rb
+++ b/lib/bump/cli/commands/deploy.rb
@@ -9,12 +9,13 @@ module Bump
         option :id, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation public id"
         option :token, default: ENV.fetch("BUMP_TOKEN", ""), desc: "Documentation private token"
         option :specification, desc: "Specification of the definition"
+        option :validation, desc: "Validation mode", values: %w(basic strict), default: 'basic'
 
-        def call(file:, id:, token:, specification: nil)
+        def call(file:, id:, token:, validation:, specification: nil)
           with_errors_rescued do
             response = post(
               url: API_URL + "/docs/#{id}/versions",
-              body: body(file, specification).to_json,
+              body: body(file, specification, validation).to_json,
               token: token
             )
 

--- a/lib/bump/cli/commands/preview.rb
+++ b/lib/bump/cli/commands/preview.rb
@@ -5,12 +5,13 @@ module Bump
         desc "Create a documentation preview for the given file"
         argument :file, required: true, desc: "Path or URL to your API documentation file. OpenAPI (2.0 to 3.0.2) and AsyncAPI (2.0) specifications are currently supported."
         option :specification, desc: "Specification of the definition"
+        option :validation, desc: "Validation mode", values: %w(basic strict), default: 'basic'
 
-        def call(file:, specification: nil)
+        def call(file:, validation:, specification: nil)
           with_errors_rescued do
             response = post(
               url: API_URL + "/previews",
-              body: body(file, specification).to_json
+              body: body(file, specification, validation).to_json
             )
 
             if response.code == 201

--- a/lib/bump/cli/commands/validate.rb
+++ b/lib/bump/cli/commands/validate.rb
@@ -9,12 +9,13 @@ module Bump
         option :id, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation public id"
         option :token, default: ENV.fetch("BUMP_TOKEN", ""), desc: "Documentation private token"
         option :specification, desc: "Specification of the definition"
+        option :validation, desc: "Validation mode", values: %w(basic strict), default: 'basic'
 
-        def call(file:, id:, token:, specification: nil)
+        def call(file:, id:, token:, validation:, specification: nil)
           with_errors_rescued do
             response = post(
               url: API_URL + "/docs/#{id}/validations",
-              body: body(file, specification).to_json,
+              body: body(file, specification, validation).to_json,
               token: token
             )
 

--- a/spec/bump/commands/deploy_spec.rb
+++ b/spec/bump/commands/deploy_spec.rb
@@ -5,13 +5,14 @@ describe Bump::CLI::Commands::Deploy do
     stub_bump_api_validate('versions/post_success.http')
 
     expect do
-      new_command.call(id: '1', token:'token', file: 'path/to/file', specification: 'openapi/v2/json')
+      new_command.call(id: '1', token:'token', file: 'path/to/file', specification: 'openapi/v2/json', validation: 'strict')
     end.to output(/New version has been successfully deployed/).to_stdout
 
     expect(WebMock).to have_requested(:post,'https://bump.sh/api/v1/docs/1/versions').with(
       body: {
         definition: 'body',
-        specification: 'openapi/v2/json'
+        specification: 'openapi/v2/json',
+        validation: 'strict'
       }
     )
   end
@@ -21,7 +22,7 @@ describe Bump::CLI::Commands::Deploy do
 
     expect do
       begin
-        new_command.call(id: '1', token: 'token', file: 'path/to/file', specification: 'openapi/v2/yaml')
+        new_command.call(id: '1', token: 'token', file: 'path/to/file', specification: 'openapi/v2/yaml', validation: 'basic')
       rescue SystemExit; end
     end.to output(/Invalid request/).to_stderr
   end
@@ -31,7 +32,7 @@ describe Bump::CLI::Commands::Deploy do
 
     expect do
       begin
-        new_command.call(id: '1', token: 'token', file: 'path/to/file', specification: 'openapi/v2/yaml')
+        new_command.call(id: '1', token: 'token', file: 'path/to/file', specification: 'openapi/v2/yaml', validation: 'basic')
       rescue SystemExit; end
     end.to output(/Unknown error/).to_stderr
   end

--- a/spec/bump/commands/preview_spec.rb
+++ b/spec/bump/commands/preview_spec.rb
@@ -5,7 +5,7 @@ describe Bump::CLI::Commands::Preview do
     stub_bump_api_create_preview('previews/post_success.http')
 
     expect do
-      new_command.call(file: 'path/to/file', specification: 'openapi/v3/yaml')
+      new_command.call(file: 'path/to/file', specification: 'openapi/v3/yaml', validation: 'strict')
     end.to output(/Preview created/).to_stdout
 
     expect(WebMock).to have_requested(:post,'https://bump.sh/api/v1/previews').with(
@@ -14,7 +14,8 @@ describe Bump::CLI::Commands::Preview do
       },
       body: {
         definition: 'body',
-        specification: 'openapi/v3/yaml'
+        specification: 'openapi/v3/yaml',
+        validation: 'strict'
       }
     )
   end
@@ -24,7 +25,7 @@ describe Bump::CLI::Commands::Preview do
 
     expect do
       begin
-        new_command.call(file: 'path/to/file', specification: 'openapi/v2/yaml')
+        new_command.call(file: 'path/to/file', specification: 'openapi/v2/yaml', validation: 'basic')
       rescue SystemExit; end
     end.to output(/Invalid request/).to_stderr
 
@@ -36,7 +37,7 @@ describe Bump::CLI::Commands::Preview do
 
     expect do
       begin
-        new_command.call(file: 'path/to/file', specification: 'openapi/v2/yaml')
+        new_command.call(file: 'path/to/file', specification: 'openapi/v2/yaml', validation: 'basic')
       rescue SystemExit; end
     end.to output(/Oops. Something bad happened./).to_stderr
 

--- a/spec/bump/commands/validate_spec.rb
+++ b/spec/bump/commands/validate_spec.rb
@@ -5,13 +5,14 @@ describe Bump::CLI::Commands::Validate do
     stub_bump_api_validate('validations/post_success.http')
 
     expect do
-      new_command.call(id: '1', token:'token', file: 'path/to/file', specification: 'api-blueprint/v1a9')
+      new_command.call(id: '1', token:'token', file: 'path/to/file', specification: 'api-blueprint/v1a9', validation: 'strict')
     end.to output(/Definition is valid/).to_stdout
 
     expect(WebMock).to have_requested(:post,'https://bump.sh/api/v1/docs/1/validations').with(
       body: {
         definition: 'body',
-        specification: 'api-blueprint/v1a9'
+        specification: 'api-blueprint/v1a9',
+        validation: 'strict'
       }
     )
   end
@@ -21,7 +22,7 @@ describe Bump::CLI::Commands::Validate do
 
     expect do
       begin
-        new_command.call(id: '1', token:'token', file: 'path/to/file', specification: 'openapi/v2/yaml')
+        new_command.call(id: '1', token:'token', file: 'path/to/file', specification: 'openapi/v2/yaml', validation: 'basic')
       rescue SystemExit; end
     end.to output(/Invalid request/).to_stderr
   end
@@ -31,7 +32,7 @@ describe Bump::CLI::Commands::Validate do
 
     expect do
       begin
-        new_command.call(id: '1', token:'token', file: 'path/to/file', specification: 'openapi/v2/yaml')
+        new_command.call(id: '1', token:'token', file: 'path/to/file', specification: 'openapi/v2/yaml', validation: 'basic')
       rescue SystemExit; end
     end.to output(/Unknown error/).to_stderr
   end


### PR DESCRIPTION
We can now choose if we want a basic (default) validation of the specification server side, or a strict one.