### PR TITLE
Migrate to Dry::CLI

### DIFF
--- a/bump-cli.gemspec
+++ b/bump-cli.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency "hanami-cli", '~> 0'
+  spec.add_dependency "dry-cli", '~> 0'
   spec.add_dependency "http", '>= 3'
 
   spec.add_development_dependency "bundler", "~> 1"

--- a/lib/bump/cli.rb
+++ b/lib/bump/cli.rb
@@ -1,5 +1,5 @@
 require "bump/cli/version"
-require "hanami/cli"
+require "dry/cli"
 require "http"
 
 module Bump
@@ -9,11 +9,11 @@ module Bump
     API_URL = ROOT_URL + API_PATH
 
     def call(*args)
-      Hanami::CLI.new(Commands).call(*args)
+      Dry::CLI.new(Commands).call(*args)
     end
 
     module Commands
-      extend Hanami::CLI::Registry
+      extend Dry::CLI::Registry
     end
   end
 end

--- a/lib/bump/cli/commands/base.rb
+++ b/lib/bump/cli/commands/base.rb
@@ -4,7 +4,7 @@ require 'bump/cli/tools/uuid'
 module Bump
   class CLI
     module Commands
-      class Base < Hanami::CLI::Command
+      class Base < Dry::CLI::Command
         USER_AGENT = "bump-cli/#{VERSION}".freeze
 
         private

--- a/spec/bump/commands/base_spec.rb
+++ b/spec/bump/commands/base_spec.rb
@@ -20,7 +20,7 @@ describe Bump::CLI::Commands::Base do
   end
 
   it 'calls the given url with correct headers and body' do
-    command = Bump::CLI::Commands::BasePost.new(command_name: 'Fake')
+    command = Bump::CLI::Commands::BasePost.new
     stub_request(:post, "http://somewhere/")
 
     command.call(url: 'http://somewhere', body: 'hello world', token: '4815162342')
@@ -35,7 +35,7 @@ describe Bump::CLI::Commands::Base do
   end
 
   it 'handles IO errors' do
-    command = Bump::CLI::Commands::BaseErrors.new(command_name: 'Fake')
+    command = Bump::CLI::Commands::BaseErrors.new
 
     expect do
       begin
@@ -47,7 +47,7 @@ describe Bump::CLI::Commands::Base do
   end
 
   it 'handles socket errors' do
-    command = Bump::CLI::Commands::BaseErrors.new(command_name: 'Fake')
+    command = Bump::CLI::Commands::BaseErrors.new
 
     expect do
       begin
@@ -59,7 +59,7 @@ describe Bump::CLI::Commands::Base do
   end
 
   it 'handles http errors' do
-    command = Bump::CLI::Commands::BaseErrors.new(command_name: 'Fake')
+    command = Bump::CLI::Commands::BaseErrors.new
 
     expect do
       begin
@@ -71,7 +71,7 @@ describe Bump::CLI::Commands::Base do
   end
 
   it 'handles validation error' do
-    command = Bump::CLI::Commands::BasePost.new(command_name: 'Fake')
+    command = Bump::CLI::Commands::BasePost.new
     stub_request(:post, "http://somewhere/").to_return(
       status: 422,
       body: { 'errors' =>  { 'raw_definition' => ['This is an error'] } }.to_json
@@ -85,7 +85,7 @@ describe Bump::CLI::Commands::Base do
   end
 
   it 'handles validation errors even when backend returns shit' do
-    command = Bump::CLI::Commands::BasePost.new(command_name: 'Fake')
+    command = Bump::CLI::Commands::BasePost.new
     stub_request(:post, "http://somewhere/").to_return(
       status: 422,
       body: { 'message' => 'Invalid', 'errors' => { 'attribute' => 'message' } }.to_json

--- a/spec/bump/commands/deploy_spec.rb
+++ b/spec/bump/commands/deploy_spec.rb
@@ -92,7 +92,7 @@ describe Bump::CLI::Commands::Deploy do
   end
 
   def new_command
-    command = Bump::CLI::Commands::Deploy.new(command_name: 'validate')
+    command = Bump::CLI::Commands::Deploy.new
     allow(command).to receive(:open).and_return(double(read: 'body'))
     command
   end

--- a/spec/bump/commands/preview_spec.rb
+++ b/spec/bump/commands/preview_spec.rb
@@ -51,7 +51,7 @@ describe Bump::CLI::Commands::Preview do
   end
 
   def new_command
-    command = Bump::CLI::Commands::Preview.new(command_name: 'preview')
+    command = Bump::CLI::Commands::Preview.new
     allow(command).to receive(:open).and_return(double(read: 'body'))
     command
   end

--- a/spec/bump/commands/validate_spec.rb
+++ b/spec/bump/commands/validate_spec.rb
@@ -92,7 +92,7 @@ describe Bump::CLI::Commands::Validate do
   end
 
   def new_command
-    command = Bump::CLI::Commands::Validate.new(command_name: 'validate')
+    command = Bump::CLI::Commands::Validate.new
     allow(command).to receive(:open).and_return(double(read: 'body'))
     command
   end


### PR DESCRIPTION
Hanami::CLI has been renamed into Dry::CLI.

https://dev.to/ivanshamatov/dry-cli-updates-39kk