### PR TITLE
Allow upgraded bundler version in development dependency

### DIFF
--- a/bump-cli.gemspec
+++ b/bump-cli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hanami-cli", '~> 0'
   spec.add_dependency "http", '>= 3'
 
-  spec.add_development_dependency "bundler", "~> 1"
+  spec.add_development_dependency "bundler", ">= 1", "< 3"
   spec.add_development_dependency "byebug", "~> 11"
   spec.add_development_dependency "climate_control", '~> 0'
   spec.add_development_dependency "rake", "~> 13"


### PR DESCRIPTION
Allowing bundler version 2 in the development dependency

What do you think about it?