### PR TITLE
Fix arrays breaking references resolving

### DIFF
--- a/lib/bump/cli/references.rb
+++ b/lib/bump/cli/references.rb
@@ -25,12 +25,16 @@ module Bump
 
       attr_reader :base_path, :processed, :external_references
 
-      def traverse_and_replace_external_references(current, parent = nil)
+      def traverse_and_replace_external_references(current)
         current.each do |key, value|
           if key == '$ref'
             current[key] = replace_external_reference(value)
           elsif value.is_a?(Hash)
-            traverse_and_replace_external_references(value, key)
+            traverse_and_replace_external_references(value)
+          elsif value.is_a?(Array)
+            value.each do |array_value|
+              traverse_and_replace_external_references(array_value)
+            end
           end
         end
       end

--- a/spec/bump/references_spec.rb
+++ b/spec/bump/references_spec.rb
@@ -118,5 +118,19 @@ describe Bump::CLI::References do
       expect(references.definition.dig('components', 'x-imported', '1')).to eq('content')
       expect(references).to have_received(:open).with('http://example.com/file.xml')
     end
+
+    it 'imports arrays with references' do
+      references = Bump::CLI::References.new({
+        'hello' => [
+          { '$ref' => 'https://some.url/path' }
+        ]
+      })
+      allow(references).to receive(:open).and_return(spy(read: 'content'))
+
+      references.import!
+
+      expect(references.definition['hello'][0]['$ref']).to eq('#/components/x-imported/1')
+      expect(references.definition.dig('components', 'x-imported', '1')).to eq('content')
+    end
   end
 end


### PR DESCRIPTION
We weren't parsing arrays, so external references inside an array weren't imported 😱 