### PR TITLE
Fallback to simple text when unable to parse an external reference

### DIFF
--- a/lib/bump/cli/parser.rb
+++ b/lib/bump/cli/parser.rb
@@ -7,9 +7,11 @@ module Bump
       def load(content)
         [:json, ::JSON.parse(content)]
       rescue ::JSON::ParserError => e
-        [:yaml, ::YAML.safe_load(content, [Date, Time])]
-      rescue ::Psych::SyntaxError
-        raise 'Invalid format: definition file should be valid YAML or JSON'
+        begin
+          [:yaml, ::YAML.safe_load(content, [Date, Time])]
+        rescue ::Psych::SyntaxError
+          [:text, content]
+        end
       end
 
       def dump(definition, format)

--- a/spec/bump/parser_spec.rb
+++ b/spec/bump/parser_spec.rb
@@ -15,6 +15,13 @@ describe Bump::CLI::Parser do
       expect(format).to eq(:json)
       expect(definition).to eq('property' => 'value')
     end
+
+    it 'correctly fallbacks to simple text definition' do
+      format, definition = Bump::CLI::Parser.new.load("Not valid YAML: something.\n 0: #nop!")
+
+      expect(format).to eq(:text)
+      expect(definition).to eq("Not valid YAML: something.\n 0: #nop!")
+    end
   end
 
   describe '#dump' do


### PR DESCRIPTION
This will allow us to support Markdown files as external references, for topics or any content in a specification.