### PR TITLE
Support Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build-latest: &common-build
     working_directory: ~/bump-cli
     docker:
-      - image: circleci/ruby:2.5.0-node
+      - image: circleci/ruby:latest
     steps:
       - checkout
       - run:
@@ -29,20 +29,30 @@ jobs:
 
       - run:
           name: Run tests
-          command: rake
+          command: bundle exec rspec
+  build-2-6:
+    <<: *common-build
+    docker:
+      - image: circleci/ruby:2.6
+  build-2-5:
+    <<: *common-build
+    docker:
+      - image: circleci/ruby:2.5
   build-2-4:
     <<: *common-build
     docker:
-      - image: circleci/ruby:2.4.3-node
+      - image: circleci/ruby:2.4
   build-2-3:
     <<: *common-build
     docker:
-      - image: circleci/ruby:2.3.6-node
+      - image: circleci/ruby:2.3
 
 workflows:
   version: 2
   build:
     jobs:
       - build-latest
+      - build-2-6
+      - build-2-5
       - build-2-4
       - build-2-3

--- a/lib/bump/cli/commands/deploy.rb
+++ b/lib/bump/cli/commands/deploy.rb
@@ -20,7 +20,7 @@ module Bump
           with_errors_rescued do
             response = post(
               url: API_URL + "/versions",
-              body: body(file, options).to_json,
+              body: body(file, **options).to_json,
               token: options[:token]
             )
 

--- a/lib/bump/cli/commands/preview.rb
+++ b/lib/bump/cli/commands/preview.rb
@@ -12,7 +12,7 @@ module Bump
           with_errors_rescued do
             response = post(
               url: API_URL + "/previews",
-              body: body(file, options).to_json
+              body: body(file, **options).to_json
             )
 
             if response.code == 201

--- a/lib/bump/cli/commands/validate.rb
+++ b/lib/bump/cli/commands/validate.rb
@@ -20,7 +20,7 @@ module Bump
           with_errors_rescued do
             response = post(
               url: API_URL + "/validations",
-              body: body(file, options).to_json,
+              body: body(file, **options).to_json,
               token: options[:token]
             )
 


### PR DESCRIPTION
Remove warnings we got with Ruby 2.7 and add 2.6 and 2.7 to CircleCI matrix.