### PR TITLE
Better deploy messages

### DIFF
--- a/lib/bump/cli/commands/deploy.rb
+++ b/lib/bump/cli/commands/deploy.rb
@@ -25,9 +25,9 @@ module Bump
             )
 
             if response.code == 201
-              puts "New version has been successfully deployed."
+              puts "The new version is currently being processed."
             elsif response.code == 204
-              puts "Version was already deployed."
+              puts "This version has already been deployed."
             else
               display_error(response)
             end

--- a/spec/bump/commands/deploy_spec.rb
+++ b/spec/bump/commands/deploy_spec.rb
@@ -14,7 +14,7 @@ describe Bump::CLI::Commands::Deploy do
         specification: 'openapi/v2/json',
         validation: 'strict',
         'auto-create': true)
-    end.to output(/New version has been successfully deployed/).to_stdout
+    end.to output(/The new version is currently being processed/).to_stdout
 
     expect(WebMock).to have_requested(:post,'https://bump.sh/api/v1/versions').with(
       body: {
@@ -38,7 +38,7 @@ describe Bump::CLI::Commands::Deploy do
         hub: 'hub-slug',
         file: 'path/to/file'
       )
-    end.to output(/New version has been successfully deployed/).to_stdout
+    end.to output(/The new version is currently being processed/).to_stdout
 
     expect(WebMock).to have_requested(:post,'https://bump.sh/api/v1/versions').with(
       body: hash_including(


### PR DESCRIPTION
At the beginning deployment was synchronous, so a 201 response code meant that the version was deployed. This is not true anymore, as it only means the server has accepted to process this version.