### PR TITLE
Fix arrays with scalar values

### DIFF
--- a/lib/bump/cli/references.rb
+++ b/lib/bump/cli/references.rb
@@ -33,7 +33,9 @@ module Bump
             traverse_and_replace_external_references(value)
           elsif value.is_a?(Array)
             value.each do |array_value|
-              traverse_and_replace_external_references(array_value)
+              if array_value.is_a?(Hash)
+                traverse_and_replace_external_references(array_value)
+              end
             end
           end
         end

--- a/spec/bump/references_spec.rb
+++ b/spec/bump/references_spec.rb
@@ -122,7 +122,8 @@ describe Bump::CLI::References do
     it 'imports arrays with references' do
       references = Bump::CLI::References.new({
         'hello' => [
-          { '$ref' => 'https://some.url/path' }
+          { '$ref' => 'https://some.url/path' },
+          'something_else'
         ]
       })
       allow(references).to receive(:open).and_return(spy(read: 'content'))


### PR DESCRIPTION
By supporting arrays in references calculation, we have introduced a bug for array filled with scalar values.

We now ignore scalar values and only try to resolve references on sub hashes.