### PR TITLE
Add resolve command

### DIFF
--- a/lib/bump/cli.rb
+++ b/lib/bump/cli.rb
@@ -21,8 +21,10 @@ end
 require "bump/cli/commands/base"
 require "bump/cli/commands/deploy"
 require "bump/cli/commands/preview"
+require "bump/cli/commands/resolve"
 require "bump/cli/commands/validate"
 
 Bump::CLI::Commands.register "deploy", Bump::CLI::Commands::Deploy
 Bump::CLI::Commands.register "preview", Bump::CLI::Commands::Preview
+Bump::CLI::Commands.register "resolve", Bump::CLI::Commands::Resolve
 Bump::CLI::Commands.register "validate", Bump::CLI::Commands::Validate

--- a/lib/bump/cli/commands/resolve.rb
+++ b/lib/bump/cli/commands/resolve.rb
@@ -1,0 +1,31 @@
+module Bump
+  class CLI
+    module Commands
+      class Resolve < Base
+        desc "Resolve a specification external references"
+        argument :file, required: true, desc: "Path or URL to your API documentation file. OpenAPI (2.0 to 3.0.2) and AsyncAPI (2.0) specifications are currently supported."
+        argument :destination, required: false, desc: "Destination file if not the same."
+        option :overwrite, type: :boolean, desc: "Overwrite the destination file if it already exists."
+
+        def call(file:, destination: nil, **options)
+          with_errors_rescued do
+            definition = Definition.new(file, import_external_references: true)
+            destination = destination.nil? ? file : destination
+            check_destination!(destination, options)
+
+            definition.prepare
+            definition.write(to: destination)
+
+            puts "External references have been resolved in #{destination}"
+          end
+        end
+
+        def check_destination!(destination, options)
+          if File.exists?(destination) && options[:overwrite] == false
+            abort "Destination #{destination} already exists. Use --overwrite to overwrite it."
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bump/cli/definition.rb
+++ b/lib/bump/cli/definition.rb
@@ -8,14 +8,19 @@ module Bump
       def initialize(path, import_external_references: false)
         @path = path
         @import_external_references = import_external_references
+        @content = nil
       end
 
       def prepare
         if !import_external_references
-          read_file
+          @content = read_file
         else
-          parse_file_and_import_external_references
+          @content = parse_file_and_import_external_references
         end
+      end
+
+      def write(to:)
+        File.write(to, @content)
       end
 
       private

--- a/spec/bump/commands/resolve_spec.rb
+++ b/spec/bump/commands/resolve_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+describe Bump::CLI::Commands::Resolve do
+  it "resolves and writes to the destination file" do
+    definition = spy(:definition)
+    allow(Bump::CLI::Definition).to receive(:new).and_return(definition)
+
+    expect do
+      new_command.call(
+        file: "/origin/file.yml",
+        destination: "/destination/file.yml")
+    end.to output(/External references have been resolved in \/destination\/file.yml/).to_stdout
+
+    expect(definition).to have_received(:prepare)
+    expect(definition).to have_received(:write).with(to: "/destination/file.yml")
+  end
+
+  it "allows overwriting a file if --overwrite is used" do
+    definition = spy(:definition)
+    allow(Bump::CLI::Definition).to receive(:new).and_return(definition)
+    allow(File).to receive(:exists?).and_return(true)
+
+    expect do
+      new_command.call(
+        file: "/origin/file.yml",
+        overwrite: true)
+    end.to output(/External references have been resolved in \/origin\/file.yml/).to_stdout
+  end
+
+  it "exits with an error if file exists" do
+    definition = spy(:definition)
+    allow(Bump::CLI::Definition).to receive(:new).and_return(definition)
+    allow(File).to receive(:exists?).and_return(true)
+
+    expect do
+      begin
+        new_command.call(
+          file: "/origin/file.yml",
+          overwrite: false)
+      rescue SystemExit; end
+    end.to output(/Destination \/origin\/file.yml already exists. Use --overwrite to overwrite it./).to_stderr
+  end
+
+  private
+
+  def new_command
+    command = Bump::CLI::Commands::Resolve.new
+    allow(command).to receive(:exit)
+    command
+  end
+end

--- a/spec/bump/definition_spec.rb
+++ b/spec/bump/definition_spec.rb
@@ -34,4 +34,18 @@ describe Bump::CLI::Definition do
       expect(definition.prepare).to include('{"property":"value"}')
     end
   end
+
+  describe "write" do
+    it "writes content to the given destination" do
+      definition = Bump::CLI::Definition.new('path/to/file')
+      file = spy(read: 'content')
+      allow(definition).to receive(:open).and_return(file)
+      allow(File).to receive(:write)
+
+      definition.prepare
+      definition.write(to: '/my/resolved-file.yml')
+
+      expect(File).to have_received(:write).with('/my/resolved-file.yml', 'content')
+    end
+  end
 end


### PR DESCRIPTION
This is a new command, which lets a user resolve external dependencies locally. It will help our customers with complex $ref architecture to prepare their files before sending them to Bump.

Note: the first reason I started working on this was to fix the following feature request: being able to resolve chained $references (like a ref to a file containing a ref to another file). I finally think that we'll be able to implement this request, but I think that keeping this resolve command could be useful in case users want to build file not for sending them to Bump. WDYT?