### PR TITLE
Enforce UTF-8 encoding when reading file

### DIFF
--- a/lib/bump/cli/definition.rb
+++ b/lib/bump/cli/definition.rb
@@ -28,7 +28,7 @@ module Bump
       attr_reader :path, :import_external_references
 
       def read_file
-        open(path).read
+        open(path).read.force_encoding(Encoding::UTF_8)
       end
 
       def parse_file_and_import_external_references


### PR DESCRIPTION
This avoids getting an Encoding::UndefinedConversionError exception when reading files with other encoding.

I just got the issue because of doing tests, a file not in UTF-8 was fully breaking the CLI.