### PR TITLE
doc: clarify the deprecated --id option and document BUMP_ID env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ Bump tries to identify your file specification and format automatically. You can
 * `asyncapi/v2/json`
 * `asyncapi/v2/yaml`
 
-`doc` and `token` options used below can be found in your documentation settings page on https://bump.sh. Note that you can replace the token option by an environment variable, to keep it secret: `--token` can by replaced by `BUMP_TOKEN`.
+Both the `--doc` and `--token` options used below can be found in your documentation settings page on https://bump.sh. Note that you can replace both the `--doc` and `--token` option by an environment variable. This will help to keep those values secret:
+
+- `--doc` can by replaced by `BUMP_ID`.
+- `--token` can by replaced by `BUMP_TOKEN`.
 
 ### Preview
 

--- a/lib/bump/cli/commands/deploy.rb
+++ b/lib/bump/cli/commands/deploy.rb
@@ -6,7 +6,7 @@ module Bump
       class Deploy < Base
         desc "Create a new version"
         argument :file, required: true, desc: "Path or URL to your API documentation file. OpenAPI (2.0 to 3.0.2) and AsyncAPI (2.0) specifications are currently supported."
-        option :id, default: ENV.fetch("BUMP_ID", ""), desc: "[DEPRECATED] Documentation id. Use `documentation` option instead"
+        option :id, default: ENV.fetch("BUMP_ID", ""), desc: "[DEPRECATED] Documentation id. Use the `--doc` option instead"
         option :doc, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation id or slug"
         option :'doc-name', desc: "Documentation name. Used with --auto-create flag."
         option :hub, default: ENV.fetch("BUMP_HUB_ID", ""), desc: "Hub id or slug"

--- a/lib/bump/cli/commands/validate.rb
+++ b/lib/bump/cli/commands/validate.rb
@@ -6,7 +6,7 @@ module Bump
       class Validate < Base
         desc "Validate a given file against its schema definition"
         argument :file, required: true, desc: "Path or URL to your API documentation file. OpenAPI (2.0 to 3.0.2) and AsyncAPI (2.0) specifications are currently supported."
-        option :id, default: ENV.fetch("BUMP_ID", ""), desc: "[DEPRECATED] Documentation id. Use `documentation` option instead"
+        option :id, default: ENV.fetch("BUMP_ID", ""), desc: "[DEPRECATED] Documentation id. Use the `--doc` option instead"
         option :doc, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation public id or slug"
         option :'doc-name', desc: "Documentation name. Used with --auto-create flag."
         option :hub, desc: "Hub id or slug"


### PR DESCRIPTION
This PR contents two completely separate commits which can be cherry-picked independently depending of what you think is relevant or not :slightly_smiling_face:.

- doc(commands): clarify the deprecated `--id` option
- doc(README): document the usage of `BUMP_ID` environment variable
