### PR TITLE
Import external references by default

### DIFF
--- a/lib/bump/cli/commands/base.rb
+++ b/lib/bump/cli/commands/base.rb
@@ -42,6 +42,10 @@ module Bump
           if present?(options[:id])
             puts "[DEPRECATION WARNING] --id option is deprecated. Please use --doc instead."
           end
+
+          if options[:"import-external-references"]
+            puts "[DEPRECATION WARNING] --import-external-references option is deprecated. External references are imported by default."
+          end
         end
 
         def present?(string)

--- a/lib/bump/cli/commands/base.rb
+++ b/lib/bump/cli/commands/base.rb
@@ -18,7 +18,7 @@ module Bump
         def body(file, **options)
           deprecation_warning(options)
 
-          definition = Definition.new(file, import_external_references: options[:'import-external-references'])
+          definition = Definition.new(file, import_external_references: !options[:'no-external-references'])
           definition.prepare!
 
           compact(

--- a/lib/bump/cli/commands/deploy.rb
+++ b/lib/bump/cli/commands/deploy.rb
@@ -14,6 +14,7 @@ module Bump
         option :specification, desc: "Specification of the definition"
         option :validation, desc: "Validation mode", values: %w[basic strict], default: "basic"
         option :'auto-create', type: :boolean, default: false, desc: "Automatically create the documentation if needed (only available with a hub and when specifying a slug for documentation)"
+        option :'no-external-references', type: :boolean, default: false, desc: "Do not import external references ($ref)"
         option :'import-external-references', type: :boolean, default: false, desc: "[DEPRECATED] External references are imported by default"
 
         def call(file:, **options)

--- a/lib/bump/cli/commands/deploy.rb
+++ b/lib/bump/cli/commands/deploy.rb
@@ -14,7 +14,7 @@ module Bump
         option :specification, desc: "Specification of the definition"
         option :validation, desc: "Validation mode", values: %w[basic strict], default: "basic"
         option :'auto-create', type: :boolean, default: false, desc: "Automatically create the documentation if needed (only available with a hub and when specifying a slug for documentation)"
-        option :'import-external-references', type: :boolean, default: false, desc: "Import external $refs (URI or file system) into the specification before sending it to Bump servers"
+        option :'import-external-references', type: :boolean, default: false, desc: "[DEPRECATED] External references are imported by default"
 
         def call(file:, **options)
           with_errors_rescued do

--- a/lib/bump/cli/commands/preview.rb
+++ b/lib/bump/cli/commands/preview.rb
@@ -6,6 +6,7 @@ module Bump
         argument :file, required: true, desc: "Path or URL to your API documentation file. OpenAPI (2.0 to 3.0.2) and AsyncAPI (2.0) specifications are currently supported."
         option :specification, desc: "Specification of the definition"
         option :validation, desc: "Validation mode", values: %w[basic strict], default: "basic"
+        option :'no-external-references', type: :boolean, default: false, desc: "Do not import external references ($ref)"
         option :'import-external-references', type: :boolean, default: false, desc: "[DEPRECATED] External references are imported by default"
 
         def call(file:, **options)

--- a/lib/bump/cli/commands/preview.rb
+++ b/lib/bump/cli/commands/preview.rb
@@ -6,7 +6,7 @@ module Bump
         argument :file, required: true, desc: "Path or URL to your API documentation file. OpenAPI (2.0 to 3.0.2) and AsyncAPI (2.0) specifications are currently supported."
         option :specification, desc: "Specification of the definition"
         option :validation, desc: "Validation mode", values: %w[basic strict], default: "basic"
-        option :'import-external-references', type: :boolean, default: false, desc: "Import external $refs (URI or file system) into the specification before sending it to Bump servers"
+        option :'import-external-references', type: :boolean, default: false, desc: "[DEPRECATED] External references are imported by default"
 
         def call(file:, **options)
           with_errors_rescued do

--- a/lib/bump/cli/commands/validate.rb
+++ b/lib/bump/cli/commands/validate.rb
@@ -14,6 +14,7 @@ module Bump
         option :specification, desc: "Specification of the definition"
         option :validation, desc: "Validation mode", values: %w[basic strict], default: "basic"
         option :'auto-create', type: :boolean, default: false, desc: "Automatically create the documentation if needed (only available with a hub and when specifying a slug for documentation)"
+        option :'no-external-references', type: :boolean, default: false, desc: "Do not import external references ($ref)"
         option :'import-external-references', type: :boolean, default: false, desc: "[DEPRECATED] External references are imported by default"
 
         def call(file:, **options)

--- a/lib/bump/cli/commands/validate.rb
+++ b/lib/bump/cli/commands/validate.rb
@@ -14,7 +14,7 @@ module Bump
         option :specification, desc: "Specification of the definition"
         option :validation, desc: "Validation mode", values: %w[basic strict], default: "basic"
         option :'auto-create', type: :boolean, default: false, desc: "Automatically create the documentation if needed (only available with a hub and when specifying a slug for documentation)"
-        option :'import-external-references', type: :boolean, default: false, desc: "Import external $refs (URI or file system) into the specification before sending it to Bump servers"
+        option :'import-external-references', type: :boolean, default: false, desc: "[DEPRECATED] External references are imported by default"
 
         def call(file:, **options)
           with_errors_rescued do

--- a/spec/bump/commands/deploy_spec.rb
+++ b/spec/bump/commands/deploy_spec.rb
@@ -67,6 +67,19 @@ describe Bump::CLI::Commands::Deploy do
     )
   end
 
+  it "supports deprecated id option and displays a warning" do
+    stub_bump_api_validate("versions/post_success.http")
+    allow(Bump::CLI::Resource).to receive(:read).and_return("body")
+
+    expect {
+      new_command.call(
+        doc: "here-is-my-doc",
+        file: "path/to/file",
+        "import-external-references": true
+      )
+    }.to output(/\[DEPRECATION WARNING\]/).to_stdout
+  end
+
   it "displays the definition errors in case of unprocessable entity" do
     stub_bump_api_validate("versions/post_unprocessable_entity.http")
 


### PR DESCRIPTION
Following #30, now that we have simplified a lot the references code in this project, I think that it may be a good moment to switch to a mode where we resolve/bundle all the references by default.

This is the goal of this PR.

However, we have to keep 2 things in mind:
* resolving references by default implies opening/reading/parsing the source files. So we add more logic as the default behavior, that could lead to potential bugs (that, at the moment, we don't monitor)
* the previous `--import-external-references` is now obsolete. In its current state, this PR fully removes it. It means that any call with it will lead to an error. Some of our users automatically update the gem, without any limitation about the used version, so it could break their CI until they remove the call. We can also keep it for now as a dead parameter, adding a deprecation warning as we do for the `--id` before we remove it in a new version.

@Polo2 do you have opinions on this? Maybe, also, @paulRbr if you want to have a look?