### PR TITLE
Better rescue for runtime exceptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/cli-runtime-error.md
+++ b/.github/ISSUE_TEMPLATE/cli-runtime-error.md
@@ -1,0 +1,26 @@
+---
+name: CLI runtime error
+about: Create a report of an exception happening when running a CLI command
+title: "[ERROR MESSAGE]"
+labels: ""
+assignees: ""
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Command**
+Paste here the exact command executed (with arguments and options) which led to the bug.
+
+**Stack trace**
+Paste here the stack trace displayed by the CLI, if available.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. macOS Catalina 10.15.7]
+ - Ruby version [e.g. 2.7]
+
+**Additional context**
+Add any other context about the problem here. If publishable, do not hesitate to join the specification you were trying to deploy/preview on Bump.

--- a/lib/bump/cli/commands/base.rb
+++ b/lib/bump/cli/commands/base.rb
@@ -89,6 +89,14 @@ module Bump
           yield
         rescue HTTP::Error, Errno::ENOENT, SocketError => error
           abort "Error: #{error.message}"
+        rescue => error
+          warn "An unexpected error occurred. Sorry about that!"
+          warn "We don't monitor errors raised by the CLI running on your computer, so we have not been notified."
+          warn "You can help us fix this by creating an issue on https://github.com/bump-sh/bump-cli/issues."
+          warn "\n"
+          warn "#{error.class}: #{error.message}"
+          warn error.backtrace.take(10).join("\n")
+          exit(1)
         end
 
         def headers(token: "")

--- a/lib/bump/cli/commands/base.rb
+++ b/lib/bump/cli/commands/base.rb
@@ -92,7 +92,7 @@ module Bump
         rescue => error
           warn "An unexpected error occurred. Sorry about that!"
           warn "We don't monitor errors raised by the CLI running on your computer, so we have not been notified."
-          warn "You can help us fix this by creating an issue on https://github.com/bump-sh/bump-cli/issues."
+          warn "You can help us fix this by creating an issue on https://github.com/bump-sh/bump-cli/issues/new?template=cli-runtime-error.md."
           warn "\n"
           warn "#{error.class}: #{error.message}"
           warn error.backtrace.take(10).join("\n")

--- a/spec/bump/commands/base_spec.rb
+++ b/spec/bump/commands/base_spec.rb
@@ -1,24 +1,6 @@
 require "spec_helper"
 
 describe Bump::CLI::Commands::Base do
-  class Bump::CLI::Commands::BaseErrors < Bump::CLI::Commands::Base
-    def call
-      with_errors_rescued do
-        yield
-      end
-    end
-  end
-
-  class Bump::CLI::Commands::BasePost < Bump::CLI::Commands::Base
-    def call(url:, body:, token: nil)
-      response = post(url: url, body: body, token: token)
-
-      if response.status > 400
-        display_error(response)
-      end
-    end
-  end
-
   it "calls the given url with correct headers and body" do
     command = Bump::CLI::Commands::BasePost.new
     stub_request(:post, "http://somewhere/")
@@ -96,5 +78,23 @@ describe Bump::CLI::Commands::Base do
         command.call(url: "http://somewhere", body: "hello")
       rescue SystemExit; end
     }.to output(/Invalid request:/).to_stderr
+  end
+end
+
+class Bump::CLI::Commands::BaseErrors < Bump::CLI::Commands::Base
+  def call
+    with_errors_rescued do
+      yield
+    end
+  end
+end
+
+class Bump::CLI::Commands::BasePost < Bump::CLI::Commands::Base
+  def call(url:, body:, token: nil)
+    response = post(url: url, body: body, token: token)
+
+    if response.status > 400
+      display_error(response)
+    end
   end
 end

--- a/spec/bump/commands/base_spec.rb
+++ b/spec/bump/commands/base_spec.rb
@@ -79,6 +79,16 @@ describe Bump::CLI::Commands::Base do
       rescue SystemExit; end
     }.to output(/Invalid request:/).to_stderr
   end
+
+  it "handles unexpected runtime errors" do
+    command = Bump::CLI::Commands::BaseErrors.new
+
+    expect {
+      begin
+        command.call { raise "Oops something bad happend" }
+      rescue SystemExit; end
+    }.to output(/You can help us fix this by creating an issue on https:\/\/github.com\/bump-sh\/bump-cli\/issues/).to_stderr
+  end
 end
 
 class Bump::CLI::Commands::BaseErrors < Bump::CLI::Commands::Base


### PR DESCRIPTION
With this PR, following suggestion of Paulr on #31 we add an error handler to display a more user friendly message when something bad happens.

It also adds an issue template so we guide our users through the process of informing us of a runtime error they had.