### PR TITLE
Remove --id option

### DIFF
--- a/lib/bump/cli/commands/base.rb
+++ b/lib/bump/cli/commands/base.rb
@@ -39,17 +39,9 @@ module Bump
         end
 
         def deprecation_warning(options)
-          if present?(options[:id])
-            puts "[DEPRECATION WARNING] --id option is deprecated. Please use --doc instead."
-          end
-
           if options[:"import-external-references"]
             puts "[DEPRECATION WARNING] --import-external-references option is deprecated. External references are imported by default."
           end
-        end
-
-        def present?(string)
-          !string.nil? && string != ""
         end
 
         def compact(hash)

--- a/lib/bump/cli/commands/deploy.rb
+++ b/lib/bump/cli/commands/deploy.rb
@@ -6,7 +6,6 @@ module Bump
       class Deploy < Base
         desc "Create a new version"
         argument :file, required: true, desc: "Path or URL to your API documentation file. OpenAPI (2.0 to 3.0.2) and AsyncAPI (2.0) specifications are currently supported."
-        option :id, default: ENV.fetch("BUMP_ID", ""), desc: "[DEPRECATED] Documentation id. Use the `--doc` option instead"
         option :doc, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation id or slug"
         option :'doc-name', desc: "Documentation name. Used with --auto-create flag."
         option :hub, default: ENV.fetch("BUMP_HUB_ID", ""), desc: "Hub id or slug"

--- a/lib/bump/cli/commands/validate.rb
+++ b/lib/bump/cli/commands/validate.rb
@@ -6,7 +6,6 @@ module Bump
       class Validate < Base
         desc "Validate a given file against its schema definition"
         argument :file, required: true, desc: "Path or URL to your API documentation file. OpenAPI (2.0 to 3.0.2) and AsyncAPI (2.0) specifications are currently supported."
-        option :id, default: ENV.fetch("BUMP_ID", ""), desc: "[DEPRECATED] Documentation id. Use the `--doc` option instead"
         option :doc, default: ENV.fetch("BUMP_ID", ""), desc: "Documentation public id or slug"
         option :'doc-name', desc: "Documentation name. Used with --auto-create flag."
         option :hub, desc: "Hub id or slug"

--- a/spec/bump/commands/deploy_spec.rb
+++ b/spec/bump/commands/deploy_spec.rb
@@ -104,24 +104,6 @@ describe Bump::CLI::Commands::Deploy do
 
     expect {
       new_command.call(
-        id: "old-school-id",
-        file: "path/to/file"
-      )
-    }.to output(/\[DEPRECATION WARNING\]/).to_stdout
-
-    expect(WebMock).to have_requested(:post, "https://bump.sh/api/v1/versions").with(
-      body: hash_including(
-        documentation_id: "old-school-id"
-      )
-    )
-  end
-
-  it "supports deprecated id option and displays a warning" do
-    stub_bump_api_validate("versions/post_success.http")
-    allow(Bump::CLI::Resource).to receive(:read).and_return("body")
-
-    expect {
-      new_command.call(
         doc: "here-is-my-doc",
         file: "path/to/file",
         "import-external-references": true


### PR DESCRIPTION
This option is deprecated since version 0.6. We can remove it for version 0.7.