### PR TITLE
Follow http redirections when fetching remote resources

### DIFF
--- a/lib/bump/cli/resource.rb
+++ b/lib/bump/cli/resource.rb
@@ -6,7 +6,8 @@ module Bump
     class Resource
       def self.read(location)
         if location.start_with?("http")
-          ::HTTP.get(location).to_s
+          ::HTTP.follow(max_hops: 50)
+            .get(location).to_s
         else
           ::File.read(location).force_encoding(Encoding::UTF_8)
         end


### PR DESCRIPTION
Will try to follow HTTP redirections (30x) when fetching a remote HTTP
resource. With a maximum number of redirection-followings of 50 (the
default in curl).