### PR TITLE
Deprecate Ruby CLI in favor of our new node-based Bump CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Bump::CLI
 
+**⚠️ DEPRECATION WARNING:** This repository is now deprecated in favor of our [new Node based Bump CLI](https://github.com/bump-sh/cli). Please migrate to v2.x+ version of our CLI to enjoy all features of Bump.sh. ⚠️
+
+- [**Read the new CLI announcement**](https://headwayapp.co/bump-changelog/new-command-line-interface-era-196226)
+- [**Read our Bump CLI help section**](https://help.bump.sh/bump-cli)
+
+_If you still want to use this ruby gem, please [contact us](mailto:hello@bump.sh) to discuss alternatives and share your use case. Thank you!_
+
 The `bump-cli` gem provides a simple command line access to the Bump (https://bump.sh) API.
 
 ## Installation

--- a/lib/bump/cli.rb
+++ b/lib/bump/cli.rb
@@ -9,6 +9,14 @@ module Bump
     API_URL = ROOT_URL + API_PATH
 
     def call(*args)
+      warn ":WARNING:"
+      warn "  This Bump CLI is now legacy and will not be maintained any further."
+      warn ""
+      warn "  Please update to our new v2.x CLI available at https://github.com/bump-sh/cli"
+      warn "  You can install the new Bump CLI with 'npm install -g bump-cli'"
+      warn "                                     or 'yarn global add bump-cli'"
+      warn ":WARNING:"
+      warn ""
       Dry::CLI.new(Commands).call(*args)
     end
 

--- a/spec/bump/resource_spec.rb
+++ b/spec/bump/resource_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe Bump::CLI::Resource do
   describe ".read" do
     it "handles URL location" do
+      allow(HTTP).to receive(:follow).and_return(HTTP)
       allow(HTTP).to receive(:get).and_return("hello: world")
 
       content = Bump::CLI::Resource.read("https://example.com/source.yml")


### PR DESCRIPTION
Now that we released our new node based CLI (https://github.com/bump-sh/cli) we can warn our Ruby gem users that this gem will not get any update and that they should migrate to our new CLI.